### PR TITLE
Honor multiple inheritance correctly.

### DIFF
--- a/wagtail_pgsearchbackend/utils.py
+++ b/wagtail_pgsearchbackend/utils.py
@@ -57,7 +57,7 @@ def get_descendant_models(model):
     """
     models = set([model])
     for other_model in apps.get_models():
-        if model in other_model._meta.parents:
+        if issubclass(other_model, model):
             models.add(other_model)
     return models
 


### PR DESCRIPTION
When pages have multiple levels of inheritance they are getting filtered out incorrectly.  This patch uses the same way Wagtail determines if a page is a subclass in its type and type_q filters for search.