### PR TITLE
Fix migration for Postgres < 9.5

### DIFF
--- a/wagtail_pgsearchbackend/migrations/0002_add_gin_index.py
+++ b/wagtail_pgsearchbackend/migrations/0002_add_gin_index.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            'CREATE INDEX IF NOT EXISTS {0}_body_search ON {0} '
+            'CREATE INDEX {0}_body_search ON {0} '
             'USING GIN(body_search);'.format(table),
             'DROP INDEX IF EXISTS {}_body_search;'.format(table),
         ),


### PR DESCRIPTION
CREATE INDEX IF NOT EXISTS was added in PostgreSQL 9.5

https://www.postgresql.org/docs/9.4/static/sql-createindex.html